### PR TITLE
Forward-port LPS-193731 to master so that users can upgrade directly from 7.3 U30 to master without needing to go through 7.3 U32 first

### DIFF
--- a/modules/apps/analytics/analytics-message-storage-service/src/main/java/com/liferay/analytics/message/storage/internal/upgrade/registry/AnalyticsMessageStorageServiceUpgradeStepRegistrator.java
+++ b/modules/apps/analytics/analytics-message-storage-service/src/main/java/com/liferay/analytics/message/storage/internal/upgrade/registry/AnalyticsMessageStorageServiceUpgradeStepRegistrator.java
@@ -7,6 +7,7 @@ package com.liferay.analytics.message.storage.internal.upgrade.registry;
 
 import com.liferay.analytics.message.storage.internal.upgrade.v1_1_0.util.AnalyticsDeleteMessageTable;
 import com.liferay.analytics.message.storage.internal.upgrade.v1_2_0.util.AnalyticsAssociationTable;
+import com.liferay.analytics.message.storage.internal.upgrade.v1_2_0.util.AnalyticsMessageTable;
 import com.liferay.portal.kernel.upgrade.CTModelUpgradeProcess;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
@@ -24,7 +25,9 @@ public class AnalyticsMessageStorageServiceUpgradeStepRegistrator
 		registry.register(
 			"1.0.0", "1.1.0", AnalyticsDeleteMessageTable.create());
 
-		registry.register("1.1.0", "1.2.0", AnalyticsAssociationTable.create());
+		registry.register(
+			"1.1.0", "1.2.0", AnalyticsAssociationTable.create(),
+			AnalyticsMessageTable.create());
 
 		registry.register(
 			"1.2.0", "1.3.0",

--- a/modules/apps/analytics/analytics-message-storage-service/src/main/java/com/liferay/analytics/message/storage/internal/upgrade/v1_2_0/util/AnalyticsMessageTable.java
+++ b/modules/apps/analytics/analytics-message-storage-service/src/main/java/com/liferay/analytics/message/storage/internal/upgrade/v1_2_0/util/AnalyticsMessageTable.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.analytics.message.storage.internal.upgrade.v1_2_0.util;
+
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+/**
+ * @author Brian Wing Shun Chan
+ * @generated
+ * @see com.liferay.portal.tools.upgrade.table.builder.UpgradeTableBuilder
+ */
+public class AnalyticsMessageTable {
+
+	public static UpgradeProcess create() {
+		return new UpgradeProcess() {
+
+			@Override
+			protected void doUpgrade() throws Exception {
+				if (!hasTable(_TABLE_NAME)) {
+					runSQL(_TABLE_SQL_CREATE);
+				}
+			}
+
+		};
+	}
+
+	private static final String _TABLE_NAME = "AnalyticsMessage";
+
+	private static final String _TABLE_SQL_CREATE =
+		"create table AnalyticsMessage (mvccVersion LONG default 0 not null,analyticsMessageId LONG not null primary key,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,body BLOB)";
+
+}


### PR DESCRIPTION
I tested that you could upgrade successfully from both 7.3 dxp-2 (where the `AnalyticsMessage` table exists) and from 7.3 U30 (where the `AnalyticsMessage` table does not exist) with this fix installed.

Ticket: [LPD-17038](https://liferay.atlassian.net/browse/LPD-17038)